### PR TITLE
fix(jmx): make attribute details follow page scroll

### DIFF
--- a/packages/hawtio/src/plugins/jmx/JmxContent.tsx
+++ b/packages/hawtio/src/plugins/jmx/JmxContent.tsx
@@ -87,7 +87,6 @@ export const JmxContent: React.FunctionComponent = () => {
       <PageSection
         id='jmx-content-main'
         padding={{ default: 'noPadding' }}
-        hasOverflowScroll
         aria-label='jmx-content-main'
         hasBodyWrapper={false}
       >


### PR DESCRIPTION
Hi @tadayosi, @grgrzybek, @phantomjinx , @kariuwu , @joshiraezcode ,and @jsolovjo  ! This is my first contribution to the project. I've fixed issue #2014 by removing the nested scroll container in the JMX content layout, allowing the attribute details view to follow the page scroll as expected. I'd really appreciate a review whenever you have time. Thank you!